### PR TITLE
swap latitude and longitude in description so it is correct

### DIFF
--- a/quartz_solar_forecast/pydantic_models.py
+++ b/quartz_solar_forecast/pydantic_models.py
@@ -3,6 +3,6 @@ from pydantic import BaseModel, Field
 
 class PVSite(BaseModel):
 
-    latitude: float = Field(..., description="the longitude of the site", ge=-90, le=90)
-    longitude: float = Field(..., description="the latitude of the site", ge=-180, le=180)
+    latitude: float = Field(..., description="the latitude of the site", ge=-90, le=90)
+    longitude: float = Field(..., description="the longitude of the site", ge=-180, le=180)
     capacity_kwp: float = Field(..., description="the capacity [kwp] of the site", ge=0)


### PR DESCRIPTION
# Pull Request

## Description

It looked to me like the descriptions of latitude and longitude in PVSite in  pydantic_models.py were the wrong way round, so I switched them.

## How Has This Been Tested?

I don't believe any testing is needed. I re-ran example.py and all seemed fine.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
